### PR TITLE
Fix timeout cleanup in API services

### DIFF
--- a/arcana-whiper-front/src/services/historyService.ts
+++ b/arcana-whiper-front/src/services/historyService.ts
@@ -47,13 +47,14 @@ export class HistoryService {
    * @returns 타로 카드 히스토리 응답 (페이지네이션 정보 포함)
    */
   async getTarotHistory(
-    userId: string, 
-    provider: string, 
+    userId: string,
+    provider: string,
     cursorDocId?: string
   ): Promise<HistoryResponse> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.DEFAULT_TIMEOUT);
+
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.DEFAULT_TIMEOUT);
       
       // URL 구성 - 커서가 있으면 포함
       let url = `${this.API_URL}/tarot/history?user_id=${encodeURIComponent(userId)}&provider=${encodeURIComponent(provider)}`;
@@ -71,8 +72,6 @@ export class HistoryService {
         },
         signal: controller.signal
       });
-      
-      clearTimeout(timeoutId);
       
       // 응답 오류 확인
       if (!response.ok) {
@@ -95,6 +94,8 @@ export class HistoryService {
       return data;
     } catch (error) {
       return this.handleApiError(error);
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 
@@ -130,7 +131,7 @@ export class HistoryService {
         minute: '2-digit'
       }).format(date);
     } catch (error) {
-        return dateString; // 포맷팅 실패 시 원본 문자열 반환
+      return dateString; // 포맷팅 실패 시 원본 문자열 반환
     }
   }
 

--- a/arcana-whiper-front/src/services/tarotService.ts
+++ b/arcana-whiper-front/src/services/tarotService.ts
@@ -42,10 +42,11 @@ export async function requestTarotReading(requestData: TarotRequest): Promise<Ta
     throw new Error('타로 질문이 필요합니다');
   }
   
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+
   try {
     const API_URL = import.meta.env.VITE_API_URL
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 30000);
     
     // API 호출
     const response = await fetch(`${API_URL}/tarot`, {
@@ -56,8 +57,6 @@ export async function requestTarotReading(requestData: TarotRequest): Promise<Ta
       body: JSON.stringify(requestData),
       signal: controller.signal
     });
-    
-    clearTimeout(timeoutId);
     
     // 응답 오류 확인
     if (!response.ok) {
@@ -78,6 +77,8 @@ export async function requestTarotReading(requestData: TarotRequest): Promise<Ta
       throw error;
     }
     throw new Error('알 수 없는 오류가 발생했습니다.');
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure timeouts in history and tarot services are cleared in `finally` blocks to prevent stray timers
- adjust indentation in `historyService` for readability

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: various module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840532ab10c832f93663eb31b4e07bb