### PR TITLE
chore: 프론트 배포 워크플로우와 도메인 설정을 정리

### DIFF
--- a/arcana-whiper-front/.env.example
+++ b/arcana-whiper-front/.env.example
@@ -24,3 +24,4 @@ VITE_KAKAO_JS_KEY=your-kakao-javascript-key
 # ===========================================
 # 백엔드 API URL (AWS Lambda 등)
 VITE_API_URL=https://your-api-endpoint.execute-api.region.amazonaws.com/prod
+VITE_SITE_URL=https://tarotnow.cloud

--- a/arcana-whiper-front/.github/workflows/deploy.yml
+++ b/arcana-whiper-front/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Frontend CI/CD
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || secrets.AWS_REGION || 'ap-northeast-2' }}
+  AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN || secrets.AWS_ROLE_ARN }}
+  S3_BUCKET: ${{ vars.S3_BUCKET || secrets.S3_BUCKET }}
+  CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID || secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create build environment file
+        run: |
+          cat <<'EOF' > .env.production
+          VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY || vars.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_FIREBASE_AUTH_DOMAIN || vars.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID || vars.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_FIREBASE_STORAGE_BUCKET || vars.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID || vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID=${{ secrets.VITE_FIREBASE_APP_ID || vars.VITE_FIREBASE_APP_ID }}
+          VITE_KAKAO_JS_KEY=${{ secrets.VITE_KAKAO_JS_KEY || vars.VITE_KAKAO_JS_KEY }}
+          VITE_API_URL=${{ secrets.VITE_API_URL || vars.VITE_API_URL }}
+          EOF
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+
+      - name: Upload static files to S3
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: |
+          aws s3 sync dist/ s3://$S3_BUCKET --delete --exclude "*.html" --exclude "robots.txt" --exclude "sitemap.xml" --cache-control "public, max-age=31536000, immutable"
+          aws s3 sync dist/ s3://$S3_BUCKET --delete --exclude "*" --include "*.html" --cache-control "no-cache, no-store, must-revalidate" --content-type "text/html"
+
+          if [ -f dist/robots.txt ]; then
+            aws s3 cp dist/robots.txt s3://$S3_BUCKET/robots.txt --cache-control "no-cache, max-age=300" --content-type "text/plain"
+          fi
+
+          if [ -f dist/sitemap.xml ]; then
+            aws s3 cp dist/sitemap.xml s3://$S3_BUCKET/sitemap.xml --cache-control "no-cache, max-age=300" --content-type "application/xml"
+          fi
+
+      - name: Invalidate CloudFront cache
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"

--- a/arcana-whiper-front/public/robots.txt
+++ b/arcana-whiper-front/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.aitarot.site/sitemap.xml
+Sitemap: https://tarotnow.cloud/sitemap.xml

--- a/arcana-whiper-front/public/sitemap.xml
+++ b/arcana-whiper-front/public/sitemap.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-        <loc>https://www.aitarot.site/</loc>
+        <loc>https://tarotnow.cloud/</loc>
         <lastmod>2025-12-25</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://www.aitarot.site/question</loc>
+        <loc>https://tarotnow.cloud/question</loc>
         <lastmod>2025-12-25</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://www.aitarot.site/privacy-policy.html</loc>
+        <loc>https://tarotnow.cloud/privacy-policy.html</loc>
         <lastmod>2025-12-25</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>
     </url>
     <url>
-        <loc>https://www.aitarot.site/terms-of-service.html</loc>
+        <loc>https://tarotnow.cloud/terms-of-service.html</loc>
         <lastmod>2025-12-25</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>

--- a/arcana-whiper-front/src/components/Home.tsx
+++ b/arcana-whiper-front/src/components/Home.tsx
@@ -4,12 +4,14 @@ interface HomeProps {
   onStartReading: () => void;
 }
 
+const SITE_URL = import.meta.env.VITE_SITE_URL || 'https://tarotnow.cloud';
+
 const Home: React.FC<HomeProps> = ({ onStartReading }) => {
   // SEO 설정
   useSEO({
     title: 'ArcanaWhisper - AI 타로 리딩으로 보는 운명의 메시지',
     description: 'AI 타로 리딩으로 당신의 운명을 알아보세요. 타로 카드와 인공지능이 속삭이는 운명의 메시지를 지금 확인하세요.',
-    canonical: 'https://aitarot.site'
+    canonical: SITE_URL
   });
 
   return (

--- a/arcana-whiper-front/src/hooks/useStructuredData.ts
+++ b/arcana-whiper-front/src/hooks/useStructuredData.ts
@@ -2,12 +2,13 @@ import { useEffect } from 'react';
 
 export const useStructuredData = () => {
   useEffect(() => {
+    const siteUrl = import.meta.env.VITE_SITE_URL || 'https://tarotnow.cloud';
     const structuredData = {
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "ArcanaWhisper - AI 타로 리딩",
       "description": "AI 타로 리딩으로 당신의 운명을 알아보세요. 타로 카드와 인공지능이 속삭이는 운명의 메시지를 지금 확인하세요.",
-      "url": "https://aitarot.site",
+      "url": siteUrl,
       "applicationCategory": "LifestyleApplication",
       "operatingSystem": "Any",
       "offers": {


### PR DESCRIPTION
## 변경 내용
- GitHub Actions 기반 프론트 CI/CD 워크플로우 추가
- `main` 브랜치에서 OIDC로 AWS에 로그인해 S3 배포 및 CloudFront 무효화 수행
- 앱 SEO URL을 `VITE_SITE_URL` 기반으로 정리
- `robots.txt`, `sitemap.xml`, `.env.example`의 도메인을 `tarotnow.cloud`로 갱신

## 검증 결과
- `npm run build` 통과
- `npm run lint` 실패
  - 기존 코드베이스 이슈로 실패했고, 이번 변경 파일과 직접 관련된 에러는 아니었음
  - 예: `QuestionInput.tsx`, `authService.ts`, `historyService.ts`의 기존 lint 에러