### PR TITLE
결과 페이지 유성우 잔상 시간을 줄입니다

### DIFF
--- a/src/styles/ReadingResult.css
+++ b/src/styles/ReadingResult.css
@@ -61,12 +61,12 @@
 
 .reading-result-container .shooting-stars span {
   position: absolute;
-  width: 100px;
+  width: 78px;
   height: 2px;
   background: linear-gradient(90deg, rgba(255, 255, 255, 1), rgba(165, 180, 252, 0.6), transparent);
   border-radius: 50%;
   transform: rotate(-45deg);
-  animation: shootingResult 6s linear infinite;
+  animation: shootingResult 5.2s ease-out infinite;
   opacity: 0;
   filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.8));
 }
@@ -108,10 +108,10 @@
 }
 
 @keyframes shootingResult {
-  0% { transform: rotate(-45deg) translateX(0) translateY(0); opacity: 0; }
-  10% { opacity: 1; }
-  70% { opacity: 1; }
-  100% { transform: rotate(-45deg) translateX(-300px) translateY(150px); opacity: 0; }
+  0% { transform: rotate(-45deg) translateX(0); opacity: 0; }
+  3% { opacity: 1; }
+  14% { transform: rotate(-45deg) translateX(-260px); opacity: 0; }
+  100% { transform: rotate(-45deg) translateX(-260px); opacity: 0; }
 }
 
 /* 홈 버튼 - 원형 아이콘 */


### PR DESCRIPTION
## 요약
결과 페이지에서 대각선 유성우가 화면에 오래 남아 무겁게 보이던 부분을 줄였습니다.

## 변경 배경
대각선 방향은 복원됐지만 일부 유성이 길게 남아 결과 페이지 집중도를 해치고 있었습니다.

## 변경 내용
### 변경한 것
- 결과 페이지 전용 유성우 꼬리 길이를 줄였습니다.
- 결과 페이지 전용 애니메이션을 ease-out 기반으로 조정했습니다.
- 초반 짧은 구간만 보이고 빠르게 사라지도록 shootingResult keyframes를 조정했습니다.

### 제거한 것
- 없습니다.

## 주요 설계 결정
공통 유성우 애니메이션은 건드리지 않고 결과 페이지 전용 스타일만 조정했습니다.

## 영향 범위
타로 결과 페이지의 유성우 시각 효과에만 영향을 줍니다.

## 테스트
- 
pm run build
- Playwright harness로 시각 확인